### PR TITLE
5867 otelcol.exporting.debug: added new types and tests

### DIFF
--- a/component/otelcol/exporter/debug/debug.go
+++ b/component/otelcol/exporter/debug/debug.go
@@ -28,8 +28,8 @@ func init() {
 // Arguments configures the otelcol.exporter.debug component.
 type exporterArguments struct {
 	Verbosity          configtelemetry.Level `river:"verbosity, attr, optional"`
-	SamplingInitial    int                   `river:"sampling_initial,attr,optional"`
-	SamplingThereafter int                   `river:"sampling_thereafter,attr,optional"`
+	SamplingInitial    int                   `river:"sampling_initial,attr, optional"`
+	SamplingThereafter int                   `river:"sampling_thereafter,attr, optional"`
 
 	// DebugMetrics configures component internal metrics. Optional.
 	DebugMetrics otelcol.DebugMetricsArguments `river:"debug_metrics,block,optional"`
@@ -37,8 +37,8 @@ type exporterArguments struct {
 
 type Arguments struct {
 	Verbosity          string `river:"verbosity, attr, optional"`
-	SamplingInitial    int    `river:"sampling_initial,attr,optional"`
-	SamplingThereafter int    `river:"sampling_thereafter,attr,optional"`
+	SamplingInitial    int    `river:"sampling_initial,attr, optional"`
+	SamplingThereafter int    `river:"sampling_thereafter,attr, optional"`
 }
 
 func (args Arguments) convertToExporter() (exporterArguments, error) {

--- a/component/otelcol/exporter/debug/debug.go
+++ b/component/otelcol/exporter/debug/debug.go
@@ -27,7 +27,6 @@ func init() {
 
 // Arguments configures the otelcol.exporter.debug component.
 type exporterArguments struct {
-	// Verbosity          configtelemetry.Level `river:"verbosity,attr,optional"`
 	Verbosity          configtelemetry.Level `river:"verbosity, attr, optional"`
 	SamplingInitial    int                   `river:"sampling_initial,attr,optional"`
 	SamplingThereafter int                   `river:"sampling_thereafter,attr,optional"`
@@ -37,21 +36,12 @@ type exporterArguments struct {
 }
 
 type Arguments struct {
-	// Verbosity          configtelemetry.Level `river:"verbosity,attr,optional"`
 	Verbosity          string `river:"verbosity, attr, optional"`
 	SamplingInitial    int    `river:"sampling_initial,attr,optional"`
 	SamplingThereafter int    `river:"sampling_thereafter,attr,optional"`
-
-	// DebugMetrics configures component internal metrics. Optional.
-	// DebugMetrics otelcol.DebugMetricsArguments `river:"debug_metrics,block,optional"`
 }
 
 func (args Arguments) convertToExporter() (exporterArguments, error) {
-	// const exporterVerbosity = map[string]configtelemetry.Level{
-	// 	"basic":    configtelemetry.LevelBasic,
-	// 	"normal":   configtelemetry.LevelNormal,
-	// 	"detailed": configtelemetry.LevelDetailed,
-	// }
 	e := &exporterArguments{
 		SamplingInitial:    args.SamplingInitial,
 		SamplingThereafter: args.SamplingThereafter,
@@ -69,11 +59,6 @@ func (args Arguments) convertToExporter() (exporterArguments, error) {
 		// debugexporter only supports basic, normal and detailed levels
 		return exporterArguments{}, fmt.Errorf("invalid verbosity %q", args.Verbosity)
 	}
-
-	// if _, ok := exporterVerbosity[args.Verbosity]; !ok {
-	// 	return exporterArguments{}, fmt.Errorf("Invalid verbosity %q", args.Verbosity)
-	// }
-
 
 	return *e, nil
 }

--- a/component/otelcol/exporter/debug/debug.go
+++ b/component/otelcol/exporter/debug/debug.go
@@ -47,21 +47,33 @@ type Arguments struct {
 }
 
 func (args Arguments) convertToExporter() (exporterArguments, error) {
-	const exporterVerbosity = map[string]configtelemetry.Level{
-		"basic":    configtelemetry.LevelBasic,
-		"normal":   configtelemetry.LevelNormal,
-		"detailed": configtelemetry.LevelDetailed,
-	}
-
-	if _, ok := exporterVerbosity[args.Verbosity]; !ok {
-		return exporterArguments{}, fmt.Errorf("Invalid verbosity %q", args.Verbosity)
-	}
-
+	// const exporterVerbosity = map[string]configtelemetry.Level{
+	// 	"basic":    configtelemetry.LevelBasic,
+	// 	"normal":   configtelemetry.LevelNormal,
+	// 	"detailed": configtelemetry.LevelDetailed,
+	// }
 	e := &exporterArguments{
-		Verbosity:          args.Verbosity,
 		SamplingInitial:    args.SamplingInitial,
 		SamplingThereafter: args.SamplingThereafter,
 	}
+
+	switch args.Verbosity {
+	case "basic":
+		e.Verbosity = configtelemetry.LevelBasic
+	case "normal":
+		e.Verbosity = configtelemetry.LevelNormal
+	case "detailed":
+		e.Verbosity = configtelemetry.LevelDetailed
+	default:
+		// Invalid verbosity
+		// debugexporter only supports basic, normal and detailed levels
+		return exporterArguments{}, fmt.Errorf("invalid verbosity %q", args.Verbosity)
+	}
+
+	// if _, ok := exporterVerbosity[args.Verbosity]; !ok {
+	// 	return exporterArguments{}, fmt.Errorf("Invalid verbosity %q", args.Verbosity)
+	// }
+
 
 	return *e, nil
 }
@@ -84,7 +96,7 @@ func (args *Arguments) SetToDefault() {
 func (args Arguments) Convert() (otelcomponent.Config, error) {
 	exporterArgs, err := args.convertToExporter()
 	if err != nil {
-		return nil, fmt.Errorf("Error in conversion to config arguments, %v", err)
+		return nil, fmt.Errorf("error in conversion to config arguments, %v", err)
 	}
 
 	return &debugexporter.Config{

--- a/component/otelcol/exporter/debug/debug.go
+++ b/component/otelcol/exporter/debug/debug.go
@@ -54,12 +54,12 @@ func (args Arguments) convertToExporter() (exporterArguments, error) {
 	}
 
 	if _, ok := exporterVerbosity[args.Verbosity]; !ok {
-		return exporterArguments{}, fmt.Errorf("Invalid verbosity in arguments %v", args)
+		return exporterArguments{}, fmt.Errorf("Invalid verbosity %q", args.Verbosity)
 	}
 
 	e := &exporterArguments{
-		Verbosity: args.Verbosity, 
-		SamplingInitial: args.SamplingInitial, 
+		Verbosity:          args.Verbosity,
+		SamplingInitial:    args.SamplingInitial,
 		SamplingThereafter: args.SamplingThereafter,
 	}
 

--- a/component/otelcol/exporter/debug/debug.go
+++ b/component/otelcol/exporter/debug/debug.go
@@ -1,6 +1,8 @@
 package debug
 
 import (
+	"fmt"
+
 	"github.com/grafana/agent/component"
 	"github.com/grafana/agent/component/otelcol"
 	"github.com/grafana/agent/component/otelcol/exporter"
@@ -23,14 +25,32 @@ func init() {
 	})
 }
 
+type Verbosity struct {
+  Type string 
+}
+
+func (v Verbosity) convert() configtelemetry.Level {
+  if (v.Type == "basic") {
+    return configtelemetry.LevelBasic
+  } else if (v.Type == "normal") {
+    return configtelemetry.LevelNormal    
+  } else if (v.Tyep == "detailed") {
+    return configtelemetry.LevelDetailed
+  } else {
+    return fmt.Errorf("invalid type in verbosity %v", v)
+  }
+
+}
+
 // Arguments configures the otelcol.exporter.debug component.
 type Arguments struct {
-	Verbosity          configtelemetry.Level `river:"verbosity,attr,optional"`
+	// Verbosity          configtelemetry.Level `river:"verbosity,attr,optional"`
+  Verbosity string                         `river:"verbosity, attr, optional"`
 	SamplingInitial    int                   `river:"sampling_initial,attr,optional"`
 	SamplingThereafter int                   `river:"sampling_thereafter,attr,optional"`
 
-	// DebugMetrics configures component internal metrics. Optional.
-	DebugMetrics otelcol.DebugMetricsArguments `river:"debug_metrics,block,optional"`
+  // DebugMetrics configures component internal metrics. Optional.
+  _ DebugMetrics otelcol.DebugMetricsArguments `river: ";"`
 }
 
 var _ exporter.Arguments = Arguments{}
@@ -64,9 +84,4 @@ func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension 
 // Exporters implements exporter.Arguments.
 func (args Arguments) Exporters() map[otelcomponent.DataType]map[otelcomponent.ID]otelcomponent.Component {
 	return nil
-}
-
-// DebugMetricsConfig implements receiver.Arguments.
-func (args Arguments) DebugMetricsConfig() otelcol.DebugMetricsArguments {
-	return args.DebugMetrics
 }

--- a/component/otelcol/exporter/debug/debug_test.go
+++ b/component/otelcol/exporter/debug/debug_test.go
@@ -5,28 +5,29 @@ import (
 
 	"github.com/grafana/agent/component/otelcol/exporter/debug"
 	"github.com/stretchr/testify/require"
+	otelcomponent "go.opentelemetry.io/collector/component"
 )
 
 func Test(t *testing.T) {
-    happyArgs := debug.Arguments{
-        Verbosity: "detailed",
-        SamplingInitial: 5,
-        SamplingThereafter: 20,
-    }
-    // Check no errors on converting to exporter args
-    otelcomp, err := happyArgs.Convert()
-    require.NoError(t, err)
-    
-    // Check that exporter is created correctly
-    err = &otelcomp.Validate()
-    require.NoError(t, err, "error on creating debug exporter config")
+	happyArgs := debug.Arguments{
+		Verbosity:          "detailed",
+		SamplingInitial:    5,
+		SamplingThereafter: 20,
+	}
+	// Check no errors on converting to exporter args
+	otelconf, err := happyArgs.Convert()
+	require.NoError(t, err)
 
-    invalidArgs := debug.Arguments{
-        Verbosity: "test",
-        SamplingInitial: 5,
-        SamplingThereafter: 20,
-    }
-    // Check error on converting invalid args
-    _, err = invalidArgs.Convert()
-    require.NotNil(t, err, "no error on invalid arguments")
+	// Check that exporter config is created correctly
+	err = otelcomponent.ValidateConfig(otelconf)
+	require.NoError(t, err, "error on creating debug exporter config")
+
+	invalidArgs := debug.Arguments{
+		Verbosity:          "test",
+		SamplingInitial:    5,
+		SamplingThereafter: 20,
+	}
+	// Check error on converting invalid args
+	_, err = invalidArgs.Convert()
+	require.NotNil(t, err, "no error on invalid arguments")
 }

--- a/component/otelcol/exporter/debug/debug_test.go
+++ b/component/otelcol/exporter/debug/debug_test.go
@@ -1,0 +1,32 @@
+package debug_test
+
+import (
+	"testing"
+
+	"github.com/grafana/agent/component/otelcol/exporter/debug"
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+    happyArgs := debug.Arguments{
+        Verbosity: "detailed",
+        SamplingInitial: 5,
+        SamplingThereafter: 20,
+    }
+    // Check no errors on converting to exporter args
+    otelcomp, err := happyArgs.Convert()
+    require.NoError(t, err)
+    
+    // Check that exporter is created correctly
+    err = &otelcomp.Validate()
+    require.NoError(t, err, "error on creating debug exporter config")
+
+    invalidArgs := debug.Arguments{
+        Verbosity: "test",
+        SamplingInitial: 5,
+        SamplingThereafter: 20,
+    }
+    // Check error on converting invalid args
+    _, err = invalidArgs.Convert()
+    require.NotNil(t, err, "no error on invalid arguments")
+}

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 	github.com/prometheus/statsd_exporter v0.22.8
 	github.com/richardartoul/molecule v1.0.1-0.20221107223329-32cfee06a052
 	github.com/rs/cors v1.10.1
-	github.com/shirou/gopsutil/v3 v3.23.10
+	github.com/shirou/gopsutil/v3 v3.23.9
 	github.com/sijms/go-ora/v2 v2.7.6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spaolacci/murmur3 v1.1.0
@@ -171,42 +171,42 @@ require (
 	github.com/wk8/go-ordered-map v0.2.0
 	github.com/xdg-go/scram v1.1.2
 	github.com/zeebo/xxh3 v1.0.2
-	go.opentelemetry.io/collector v0.89.0
-	go.opentelemetry.io/collector/component v0.89.0
+	go.opentelemetry.io/collector v0.87.0
+	go.opentelemetry.io/collector/component v0.87.0
 	go.opentelemetry.io/collector/config/configauth v0.87.0
 	go.opentelemetry.io/collector/config/configcompression v0.87.0
 	go.opentelemetry.io/collector/config/configgrpc v0.87.0
 	go.opentelemetry.io/collector/config/confighttp v0.87.0
 	go.opentelemetry.io/collector/config/confignet v0.87.0
 	go.opentelemetry.io/collector/config/configopaque v0.87.0
-	go.opentelemetry.io/collector/config/configtelemetry v0.89.0
+	go.opentelemetry.io/collector/config/configtelemetry v0.87.0
 	go.opentelemetry.io/collector/config/configtls v0.87.0
-	go.opentelemetry.io/collector/confmap v0.89.0
-	go.opentelemetry.io/collector/connector v0.89.0
-	go.opentelemetry.io/collector/consumer v0.89.0
-	go.opentelemetry.io/collector/exporter v0.89.0
+	go.opentelemetry.io/collector/confmap v0.87.0
+	go.opentelemetry.io/collector/connector v0.87.0
+	go.opentelemetry.io/collector/consumer v0.87.0
+	go.opentelemetry.io/collector/exporter v0.87.0
 	go.opentelemetry.io/collector/exporter/loggingexporter v0.87.0
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.87.0
 	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.87.0
-	go.opentelemetry.io/collector/extension v0.89.0
+	go.opentelemetry.io/collector/extension v0.87.0
 	go.opentelemetry.io/collector/extension/auth v0.87.0
-	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0018
+	go.opentelemetry.io/collector/featuregate v1.0.0-rcv0016
 	go.opentelemetry.io/collector/otelcol v0.87.0
-	go.opentelemetry.io/collector/pdata v1.0.0-rcv0018
-	go.opentelemetry.io/collector/processor v0.89.0
+	go.opentelemetry.io/collector/pdata v1.0.0-rcv0016
+	go.opentelemetry.io/collector/processor v0.87.0
 	go.opentelemetry.io/collector/processor/batchprocessor v0.87.0
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.87.0
-	go.opentelemetry.io/collector/receiver v0.89.0
+	go.opentelemetry.io/collector/receiver v0.87.0
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.87.0
 	go.opentelemetry.io/collector/semconv v0.87.0
-	go.opentelemetry.io/collector/service v0.89.0
+	go.opentelemetry.io/collector/service v0.87.0
 	go.opentelemetry.io/contrib/instrumentation/github.com/gorilla/mux/otelmux v0.45.0
 	go.opentelemetry.io/otel v1.21.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.19.0
-	go.opentelemetry.io/otel/exporters/prometheus v0.43.0
+	go.opentelemetry.io/otel/exporters/prometheus v0.42.0
 	go.opentelemetry.io/otel/metric v1.21.0
 	go.opentelemetry.io/otel/sdk v1.21.0
-	go.opentelemetry.io/otel/sdk/metric v1.20.0
+	go.opentelemetry.io/otel/sdk/metric v1.19.0
 	go.opentelemetry.io/otel/trace v1.21.0
 	go.opentelemetry.io/proto/otlp v1.0.0
 	go.uber.org/atomic v1.11.0


### PR DESCRIPTION
<!--

CONTRIBUTORS GUIDE: https://github.com/grafana/agent/blob/main/docs/developer/contributing.md#updating-the-changelog

If this is your first PR or you have not contributed in a while, we recommend
taking the time to review the guide. It gives helpful instructions for
contributors around things like how to update the changelog.

-->

#### PR Description
Added tests and abstracted verbosity type for debugexporter

#### Which issue(s) this PR fixes

<!-- Uncomment the following line if you want that GitHub issue gets automatically closed after merging the PR -->
 Fixes grafana/alloy#301

#### Notes to the Reviewer
- Added `exporterArguments` type which is a wrapper over `Arguments` and maintains an implementation that is consistent with `debugexporter`.
  - Removed `DebugMetrics` field from `Arguments` struct. However, it couldn't be completely removed because the upstream `exporter.Argument` specifies this in its interface.
  - `Arguments.Verbosity` is now a string and can be set to a string (such as `"detailed"`). `exporterArguments` deals with the conversion into `configtelemetry.Level` type
- Added tests to check that component `Config` is created from `Arguments` and error is thrown when an invalid `Verbosity` is passed

#### PR Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Tests updated